### PR TITLE
fix: update package.json URLs for GitHub repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/alangpierce/bulk-decaffeinate.git"
+    "url": "https://github.com/decaffeinate/bulk-decaffeinate.git"
   },
   "keywords": [
     "coffeescript",
@@ -32,9 +32,9 @@
     "jscodeshift-scripts-dist"
   ],
   "bugs": {
-    "url": "https://github.com/alangpierce/bulk-decaffeinate/issues"
+    "url": "https://github.com/decaffeinate/bulk-decaffeinate/issues"
   },
-  "homepage": "https://github.com/alangpierce/bulk-decaffeinate#readme",
+  "homepage": "https://github.com/decaffeinate/bulk-decaffeinate#readme",
   "devDependencies": {
     "babel-cli": "^6.16.0",
     "babel-eslint": "^7.0.0",


### PR DESCRIPTION
Hopefully this should fix things so semantic-release generates a GitHub release
in the newly-moved repo.