### PR TITLE
feat: add an --allow-invalid-constructors option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,24 +17,25 @@ some follow-up cleanups. Here's an example of checking the Hubot repo:
 ...
 > cd hubot
 > bulk-decaffeinate check
-Discovering .coffee files in the current directory...
-Trying decaffeinate on 18 files using 4 workers...
-18/18 (7 failures so far)
-Done!
-
-7 files failed to convert:
-src/adapters/shell.coffee
+Doing a dry run of decaffeinate on 18 files...
+18/18 (5 failures so far)
+5 files failed to convert:
+src/adapter.coffee
 src/adapters/campfire.coffee
 src/brain.coffee
+src/listener.coffee
 src/message.coffee
-src/user.coffee
-src/robot.coffee
-test/brain_test.coffee
 
 Wrote decaffeinate-errors.log and decaffeinate-results.json with more detailed info.
-To open failures in the online repl, run "bulk-decaffeinate view-errors"
+To open failures in the online repl, run "bulk-decaffeinate view-errors".
+To convert the successful files, run "bulk-decaffeinate convert -p decaffeinate-successful-files.txt".
 > bulk-decaffeinate view-errors
 (7 browser tabs are opened, showing all failures.)
+> bulk-decaffeinate check --allow-invalid-constructors
+Doing a dry run of decaffeinate on 18 files...
+18/18
+All checks succeeded! decaffeinate can convert all 18 files.
+Run "bulk-decaffeinate convert" to convert the files to JavaScript.
 ```
 
 Once any failures are resolved (generally by tweaking the CoffeeScript to work

--- a/src/cli.js
+++ b/src/cli.js
@@ -35,6 +35,9 @@ export default function () {
     .option('-d, --dir [path]',
       `A directory containing files to decaffeinate. All .coffee files in
                             any subdirectory of this directory are considered for decaffeinate.`)
+    .option('--allow-invalid-constructors',
+      `If specified, the --allow-invalid-constructors arg is added when
+                            invoking decaffeinate.`)
     .option('--land-base [revision]',
       `The git revision to use as the base commit when running the "land"
                             command. If none is specified, bulk-decaffeinate tries to use the

--- a/src/config/resolveConfig.js
+++ b/src/config/resolveConfig.js
@@ -25,7 +25,7 @@ export default async function resolveConfig(commander, requireValidFiles = true)
   for (let filename of currentDirFiles) {
     config = await applyPossibleConfig(filename, config);
   }
-  config = Object.assign(config, getCLIParamsConfig(commander));
+  config = getCLIParamsConfig(config, commander);
   let filesToProcess = await resolveFilesToProcess(config, requireValidFiles);
   filesToProcess = resolveFileFilter(filesToProcess, config);
   if (requireValidFiles) {
@@ -78,9 +78,8 @@ async function applyPossibleConfig(filename, config) {
 /**
  * Fill in a configuration from the CLI arguments.
  */
-function getCLIParamsConfig(commander) {
-  let {file, pathFile, dir, landBase, decaffeinatePath, jscodeshiftPath, eslintPath} = commander;
-  let config = {};
+function getCLIParamsConfig(config, commander) {
+  let {file, pathFile, dir, allowInvalidConstructors, landBase, decaffeinatePath, jscodeshiftPath, eslintPath} = commander;
   if (file && file.length > 0) {
     config.filesToProcess = file;
   }
@@ -89,6 +88,9 @@ function getCLIParamsConfig(commander) {
   }
   if (pathFile) {
     config.pathFile = pathFile;
+  }
+  if (allowInvalidConstructors) {
+    config.decaffeinateArgs = [...(config.decaffeinateArgs || []), '--allow-invalid-constructors'];
   }
   if (landBase) {
     config.landBase = landBase;

--- a/test/examples/invalid-subclass-constructor/A.coffee
+++ b/test/examples/invalid-subclass-constructor/A.coffee
@@ -1,0 +1,4 @@
+class A extends B
+  constructor: ->
+    @a = 1
+    super

--- a/test/test.js
+++ b/test/test.js
@@ -414,6 +414,21 @@ console.log(x);
       assert.equal((await exec('git rev-list --count HEAD'))[0].trim(), '4');
     });
   });
+
+  it('allows invalid constructors when specified', async function() {
+    await runWithTemplateDir('invalid-subclass-constructor', async function() {
+      await initGitRepo();
+      await runCliExpectSuccess('convert --allow-invalid-constructors');
+    });
+  });
+
+  it('does not allow invalid constructors when not specified', async function() {
+    await runWithTemplateDir('invalid-subclass-constructor', async function() {
+      await initGitRepo();
+      let {stderr} = await runCli('convert');
+      assertIncludes(stderr, 'Some files could not be convered with decaffeinate');
+    });
+  });
 });
 
 describe('fix-imports', () => {


### PR DESCRIPTION
This is useful to check a repo for decaffeinate problems without needing a
config file.