### PR TITLE
fix: add simple-git dependency, use it when checking for tracked files

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "mz": "^2.4.0",
     "nodegit": "^0.16.0",
     "opn": "^4.0.2",
-    "require-uncached": "^1.0.2"
+    "require-uncached": "^1.0.2",
+    "simple-git": "^1.70.0"
   }
 }

--- a/src/convert.js
+++ b/src/convert.js
@@ -8,7 +8,7 @@ import runWithProgressBar from './runner/runWithProgressBar';
 import CLIError from './util/CLIError';
 import execLive from './util/execLive';
 import getFilesUnderPath from './util/getFilesUnderPath';
-import gitTrackedStatus from './util/gitTrackedStatus';
+import isWorktreeEmpty from './util/isWorktreeEmpty';
 import makeCommit from './util/makeCommit';
 import pluralize from './util/pluralize';
 
@@ -164,8 +164,7 @@ Re-run with the "check" command for more details.`);
 }
 
 async function assertGitWorktreeClean() {
-  let changedFiles = await gitTrackedStatus();
-  if (changedFiles.length) {
+  if (!await isWorktreeEmpty()) {
     throw new CLIError(`\
 You have modifications to your git worktree.
 Please revert or commit them before running convert.`);

--- a/src/util/gitTrackedStatus.js
+++ b/src/util/gitTrackedStatus.js
@@ -1,9 +1,0 @@
-import Git from 'nodegit';
-
-/**
- * Get the status for all tracked files in git.
- */
-export default async function gitTrackedStatus() {
-  let repo = await Git.Repository.openExt('.', 0, '');
-  return await repo.getStatus({flags: 0});
-}

--- a/src/util/isWorktreeEmpty.js
+++ b/src/util/isWorktreeEmpty.js
@@ -1,0 +1,9 @@
+import git from 'simple-git/promise';
+
+/**
+ * Determine if there are any uncommitted changes in the git state.
+ */
+export default async function isWorktreeEmpty() {
+  const status = await git().status();
+  return status.files.length === 0;
+}


### PR DESCRIPTION
Progress toward #86
Progress toward #98

First step in moving off of nodegit, mostly taken from @refack's branch from #86.