### PR TITLE
fix: exit 1 when there is a failure at any step under a progress bar

### DIFF
--- a/src/check.js
+++ b/src/check.js
@@ -8,7 +8,9 @@ export default async function check(config) {
   let {filesToProcess, decaffeinateArgs = [], decaffeinatePath} = config;
   let decaffeinateResults = await runWithProgressBar(
     `Doing a dry run of decaffeinate on ${pluralize(filesToProcess.length, 'file')}...`,
-    filesToProcess, makeCLIFn(path => `${decaffeinatePath} ${decaffeinateArgs.join(' ')} < ${path}`));
+    filesToProcess,
+    makeCLIFn(path => `${decaffeinatePath} ${decaffeinateArgs.join(' ')} < ${path}`),
+    {allowFailures: true});
   await printResults(decaffeinateResults);
 }
 

--- a/src/convert.js
+++ b/src/convert.js
@@ -21,11 +21,12 @@ export default async function convert(config) {
   let {decaffeinateArgs = [], decaffeinatePath} = config;
 
   if (!config.skipVerify) {
-    let decaffeinateResults = await runWithProgressBar(
-      'Verifying that decaffeinate can successfully convert these files...',
-      coffeeFiles, makeCLIFn(path =>
-        `${decaffeinatePath} ${decaffeinateArgs.join(' ')} < ${path}`));
-    if (decaffeinateResults.filter(r => r.error !== null).length > 0) {
+    try {
+      await runWithProgressBar(
+        'Verifying that decaffeinate can successfully convert these files...',
+        coffeeFiles, makeCLIFn(path =>
+          `${decaffeinatePath} ${decaffeinateArgs.join(' ')} < ${path}`));
+    } catch (e) {
       throw new CLIError(`\
 Some files could not be convered with decaffeinate.
 Re-run with the "check" command for more details.`);

--- a/src/runner/runWithProgressBar.js
+++ b/src/runner/runWithProgressBar.js
@@ -1,4 +1,5 @@
 import runInParallel from './runInParallel';
+import CLIError from '../util/CLIError';
 import pluralize from '../util/pluralize';
 
 const NUM_CONCURRENT_PROCESSES = 8;
@@ -11,7 +12,7 @@ const NUM_CONCURRENT_PROCESSES = 8;
  * any other fields.
  */
 export default async function runWithProgressBar(
-    description, files, asyncFn, {runInSeries}={}) {
+    description, files, asyncFn, {runInSeries, allowFailures}={}) {
   let numProcessed = 0;
   let numFailures = 0;
   let numTotal = files.length;
@@ -19,6 +20,9 @@ export default async function runWithProgressBar(
   let numConcurrentProcesses = runInSeries ? 1 : NUM_CONCURRENT_PROCESSES;
   let results = await runInParallel(files, asyncFn, numConcurrentProcesses, ({result}) => {
     if (result.error) {
+      if (!allowFailures) {
+        throw new CLIError(`Error:\n${result.error}`);
+      }
       numFailures++;
     }
     numProcessed++;


### PR DESCRIPTION
Previously, it would just continue.