### PR TITLE
refactor: change file validation to happen explicitly

### DIFF
--- a/src/check.js
+++ b/src/check.js
@@ -1,11 +1,13 @@
 import { writeFile } from 'mz/fs';
 
+import getFilesToProcess from './config/getFilesToProcess';
 import makeCLIFn from './runner/makeCLIFn';
 import runWithProgressBar from './runner/runWithProgressBar';
 import pluralize from './util/pluralize';
 
 export default async function check(config) {
-  let {filesToProcess, decaffeinateArgs = [], decaffeinatePath} = config;
+  let {decaffeinateArgs = [], decaffeinatePath} = config;
+  let filesToProcess = await getFilesToProcess(config);
   let decaffeinateResults = await runWithProgressBar(
     `Doing a dry run of decaffeinate on ${pluralize(filesToProcess.length, 'file')}...`,
     filesToProcess,

--- a/src/cli.js
+++ b/src/cli.js
@@ -73,7 +73,7 @@ async function runCommand(command) {
     } else if (command === 'clean') {
       await clean();
     } else if (command === 'land') {
-      let config = await resolveConfig(commander, false);
+      let config = await resolveConfig(commander);
       await land(config);
     } else {
       commander.outputHelp();

--- a/src/config/getCoffeeFilesFromPathFile.js
+++ b/src/config/getCoffeeFilesFromPathFile.js
@@ -6,7 +6,7 @@ import CLIError from '../util/CLIError';
  * Read a list of .coffee files from a file and return it. Verify that all files
  * end in .coffee and that the files actually exist.
  */
-export default async function getCoffeeFilesFromPathFile(filePath, requireValidFiles) {
+export default async function getCoffeeFilesFromPathFile(filePath) {
   let fileContents = await readFile(filePath);
   let lines = fileContents.toString().split('\n');
   let resultLines = [];
@@ -16,18 +16,10 @@ export default async function getCoffeeFilesFromPathFile(filePath, requireValidF
       continue;
     }
     if (!line.endsWith('.coffee')) {
-      if (requireValidFiles) {
-        throw new CLIError(`The line "${line}" must be a file path ending in .coffee.`);
-      } else {
-        continue;
-      }
+      throw new CLIError(`The file "${line}" must end with .coffee.`);
     }
     if (!(await exists(line))) {
-      if (requireValidFiles) {
-        throw new CLIError(`The file "${line}" did not exist.`);
-      } else {
-        continue;
-      }
+      throw new CLIError(`The file "${line}" did not exist.`);
     }
     resultLines.push(line);
   }

--- a/src/config/getFilesToProcess.js
+++ b/src/config/getFilesToProcess.js
@@ -1,0 +1,46 @@
+import { exists } from 'mz/fs';
+import { resolve } from 'path';
+
+import getCoffeeFilesFromPathFile from './getCoffeeFilesFromPathFile';
+import getCoffeeFilesUnderPath from './getCoffeeFilesUnderPath';
+import CLIError from '../util/CLIError';
+
+export default async function getFilesToProcess(config) {
+  let filesToProcess = await resolveFilesToProcess(config);
+  filesToProcess = resolveFileFilter(filesToProcess, config);
+  await validateFilesToProcess(filesToProcess);
+  return filesToProcess;
+}
+
+async function resolveFilesToProcess(config) {
+  let {filesToProcess, pathFile, searchDirectory} = config;
+  if (filesToProcess) {
+    return filesToProcess;
+  }
+  if (pathFile) {
+    return await getCoffeeFilesFromPathFile(pathFile);
+  }
+  if (searchDirectory) {
+    return await getCoffeeFilesUnderPath(searchDirectory);
+  }
+  return await getCoffeeFilesUnderPath('.');
+}
+
+function resolveFileFilter(filesToProcess, config) {
+  if (!config.fileFilterFn) {
+    return filesToProcess;
+  }
+  return filesToProcess.filter(path => config.fileFilterFn(resolve(path)));
+}
+
+async function validateFilesToProcess(filesToProcess) {
+  for (let file of filesToProcess) {
+    if (!file.endsWith('.coffee')) {
+      throw new CLIError(`The file ${file} did not end with .coffee.`);
+    }
+    let jsFile = file.substring(0, file.length - '.coffee'.length) + '.js';
+    if (await exists(jsFile)) {
+      throw new CLIError(`The file ${jsFile} already exists.`);
+    }
+  }
+}

--- a/src/convert.js
+++ b/src/convert.js
@@ -4,6 +4,7 @@ import path from 'path';
 import git from 'simple-git/promise';
 import zlib from 'zlib';
 
+import getFilesToProcess from './config/getFilesToProcess';
 import makeCLIFn from './runner/makeCLIFn';
 import runWithProgressBar from './runner/runWithProgressBar';
 import CLIError from './util/CLIError';
@@ -16,7 +17,7 @@ import pluralize from './util/pluralize';
 export default async function convert(config) {
   await assertGitWorktreeClean();
 
-  let coffeeFiles = config.filesToProcess;
+  let coffeeFiles = await getFilesToProcess(config);
   let baseFiles = getBaseFiles(coffeeFiles);
   let {decaffeinateArgs = [], decaffeinatePath} = config;
 

--- a/test/bulk-decaffeinate-test.js
+++ b/test/bulk-decaffeinate-test.js
@@ -62,9 +62,11 @@ describe('simple-error', () => {
 
 describe('file-list', () => {
   it('reads a path file containing two lines, and ignores the other file', async function() {
-    let {stdout} = await runCli('check --path-file test/examples/file-list/files-to-decaffeinate.txt');
-    assertIncludes(stdout, 'Doing a dry run of decaffeinate on 3 files...');
-    assertIncludes(stdout, 'All checks succeeded');
+    await runWithTemplateDir('file-list', async function () {
+      let {stdout} = await runCli('check --path-file ./files-to-decaffeinate.txt');
+      assertIncludes(stdout, 'Doing a dry run of decaffeinate on 3 files...');
+      assertIncludes(stdout, 'All checks succeeded');
+    });
   });
 });
 

--- a/test/convert-test.js
+++ b/test/convert-test.js
@@ -49,20 +49,20 @@ Sample User <sample@example.com> Initial commit
 `
       );
     });
+  });
 
-    it('generates a nice commit message when converting three files', async function() {
-      await runWithTemplateDir('file-list', async function () {
-        await initGitRepo();
-        await runCliExpectSuccess('convert --path-file ./files-to-decaffeinate.txt');
-        let logStdout = (await exec('git log --pretty="%an <%ae> %s"'))[0];
-        assert.equal(logStdout, `\
+  it('generates a nice commit message when converting three files', async function() {
+    await runWithTemplateDir('file-list', async function () {
+      await initGitRepo();
+      await runCliExpectSuccess('convert --path-file ./files-to-decaffeinate.txt');
+      let logStdout = (await exec('git log --pretty="%an <%ae> %s"'))[0];
+      assert.equal(logStdout, `\
 decaffeinate <sample@example.com> decaffeinate: Run post-processing cleanups on A.coffee and 2 other files
 decaffeinate <sample@example.com> decaffeinate: Convert A.coffee and 2 other files to JS
 decaffeinate <sample@example.com> decaffeinate: Rename A.coffee and 2 other files from .coffee to .js
 Sample User <sample@example.com> Initial commit
 `
-        );
-      });
+      );
     });
   });
 

--- a/test/examples/file-list/files-to-decaffeinate.txt
+++ b/test/examples/file-list/files-to-decaffeinate.txt
@@ -1,3 +1,3 @@
-test/examples/file-list/A.coffee
-test/examples/file-list/C.coffee
-test/examples/file-list/D.coffee
+./A.coffee
+./C.coffee
+./D.coffee


### PR DESCRIPTION
Previously, it happened at config resolution time, which was awkward because
some commands didn't care about the list of files.

This also sets us up to make the set of files more flexible.