### PR TITLE
feat: change file resolution algorithm to union all specifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ module.exports = {
 The following config keys can be specified:
 
 * `searchDirectory`: a path to a directory where bulk-decaffeinate will search
-  for all .coffee files (ignoring files in `node_modules` directories).
+  for all CoffeeScript files (ignoring files in `node_modules` directories).
 * `pathFile`: a path to a file containing a list of .coffee file paths to
   process, one per line.
 * `filesToProcess`: an array of .coffee file paths to process.
@@ -163,8 +163,9 @@ The following config keys can be specified:
   run after the normal file discovery process, and is useful if there are
   specific files or directories that should not be converted.
 
-The `filesToProcess` setting has highest precedence, then `pathFile`, then
-`searchDirectory`.
+If multiple of `searchDirectory`, `pathFile`, or `filesToProcess` are specified,
+the union of the files is taken. If none is specified, bulk-decaffeinate will
+recursively discover all CoffeeScript files in the working directory.
 
 Each of these has a command line arg version; see the result of `--help` for
 more information.

--- a/src/config/getFilesToProcess.js
+++ b/src/config/getFilesToProcess.js
@@ -15,23 +15,29 @@ export default async function getFilesToProcess(config) {
 
 async function resolveFilesToProcess(config) {
   let {filesToProcess, pathFile, searchDirectory} = config;
+  if (!filesToProcess && !pathFile && !searchDirectory) {
+    return await getFilesUnderPath('.', shouldConvertFile);
+  }
+  let files = [];
   if (filesToProcess) {
-    return filesToProcess;
+    files.push(...filesToProcess);
   }
   if (pathFile) {
-    return await getFilesFromPathFile(pathFile);
+    files.push(...await getFilesFromPathFile(pathFile));
   }
   if (searchDirectory) {
-    return await getFilesUnderPath(searchDirectory, shouldConvertFile);
+    files.push(...await getFilesUnderPath(searchDirectory, shouldConvertFile));
   }
-  return await getFilesUnderPath('.', shouldConvertFile);
+  files = files.map(path => resolve(path));
+  files = Array.from(new Set(files)).sort();
+  return files;
 }
 
 function resolveFileFilter(filesToProcess, config) {
   if (!config.fileFilterFn) {
     return filesToProcess;
   }
-  return filesToProcess.filter(path => config.fileFilterFn(resolve(path)));
+  return filesToProcess.filter(path => config.fileFilterFn(path));
 }
 
 async function validateFilesToProcess(filesToProcess) {

--- a/src/config/resolveConfig.js
+++ b/src/config/resolveConfig.js
@@ -1,5 +1,5 @@
 import { exec } from 'mz/child_process';
-import { exists, readdir, readFile, stat } from 'mz/fs';
+import { exists, readdir, stat } from 'mz/fs';
 import readline from 'mz/readline';
 import { resolve } from 'path';
 import requireUncached from 'require-uncached';
@@ -46,15 +46,7 @@ async function applyPossibleConfig(filename, config) {
   }
 
   let filePath = resolve(filename);
-  if (filename.endsWith('.json')) {
-    try {
-      let newConfig = JSON.parse(await readFile(filePath));
-      return Object.assign(config, newConfig);
-    } catch (e) {
-      throw new CLIError(
-        `Error reading file ${filePath}. Make sure it is a valid JSON file.`);
-    }
-  } else if (filename.endsWith('.config.js')) {
+  if (filename.endsWith('.config.js')) {
     try {
       let newConfig = requireUncached(filePath);
       return Object.assign(config, newConfig);

--- a/test/bulk-decaffeinate-test.js
+++ b/test/bulk-decaffeinate-test.js
@@ -3,7 +3,6 @@ import assert from 'assert';
 import { readFile } from 'mz/fs';
 
 import {
-  assertFileContents,
   assertFileIncludes,
   assertIncludes,
   runCli,
@@ -49,17 +48,17 @@ describe('check', () => {
 
     await assertFileIncludes(
       'decaffeinate-errors.log',
-      '===== test/examples/simple-error/error.coffee'
+      'test/examples/simple-error/error.coffee'
     );
 
     let results = JSON.parse((await readFile('decaffeinate-results.json')).toString());
     assert.equal(results.length, 2);
-    assert.equal(results[0].path, 'test/examples/simple-error/error.coffee');
+    assert(results[0].path.endsWith('test/examples/simple-error/error.coffee'));
     assert.notEqual(results[0].error, null);
-    assert.equal(results[1].path, 'test/examples/simple-error/success.coffee');
+    assert(results[1].path.endsWith('test/examples/simple-error/success.coffee'));
     assert.equal(results[1].error, null);
 
-    await assertFileContents(
+    await assertFileIncludes(
       'decaffeinate-successful-files.txt',
       'test/examples/simple-error/success.coffee'
     );

--- a/test/convert-test.js
+++ b/test/convert-test.js
@@ -4,6 +4,7 @@ import { exec } from 'mz/child_process';
 import { exists, readFile, writeFile } from 'mz/fs';
 
 import {
+  assertExists,
   assertFileContents,
   assertIncludes,
   initGitRepo,
@@ -63,6 +64,21 @@ decaffeinate <sample@example.com> decaffeinate: Rename A.coffee and 2 other file
 Sample User <sample@example.com> Initial commit
 `
       );
+    });
+  });
+
+  it('combines multiple path specifiers', async function() {
+    await runWithTemplateDir('multiple-path-specifiers', async function () {
+      await initGitRepo();
+      await runCliExpectSuccess('convert');
+      await assertExists('./A.js');
+      await assertExists('./B.js');
+      await assertExists('./C.js');
+      await assertExists('./D.coffee');
+      await assertExists('./dir1/E.js');
+      await assertExists('./dir1/F.js');
+      await assertExists('./dir2/G.coffee');
+      await assertExists('./dir2/H.js');
     });
   });
 

--- a/test/examples/multiple-path-specifiers/A.coffee
+++ b/test/examples/multiple-path-specifiers/A.coffee
@@ -1,0 +1,1 @@
+console.log 'A'

--- a/test/examples/multiple-path-specifiers/B.coffee
+++ b/test/examples/multiple-path-specifiers/B.coffee
@@ -1,0 +1,1 @@
+console.log 'B'

--- a/test/examples/multiple-path-specifiers/C.coffee
+++ b/test/examples/multiple-path-specifiers/C.coffee
@@ -1,0 +1,1 @@
+console.log 'C'

--- a/test/examples/multiple-path-specifiers/D.coffee
+++ b/test/examples/multiple-path-specifiers/D.coffee
@@ -1,0 +1,1 @@
+console.log 'D'

--- a/test/examples/multiple-path-specifiers/bulk-decaffeinate.config.js
+++ b/test/examples/multiple-path-specifiers/bulk-decaffeinate.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  searchDirectory: './dir1',
+  pathFile: './paths.txt',
+  filesToProcess: [
+    './A.coffee',
+    './B.coffee',
+  ],
+};

--- a/test/examples/multiple-path-specifiers/dir1/E.coffee
+++ b/test/examples/multiple-path-specifiers/dir1/E.coffee
@@ -1,0 +1,1 @@
+console.log 'E'

--- a/test/examples/multiple-path-specifiers/dir1/F.coffee
+++ b/test/examples/multiple-path-specifiers/dir1/F.coffee
@@ -1,0 +1,1 @@
+console.log 'F'

--- a/test/examples/multiple-path-specifiers/dir2/G.coffee
+++ b/test/examples/multiple-path-specifiers/dir2/G.coffee
@@ -1,0 +1,1 @@
+console.log 'G'

--- a/test/examples/multiple-path-specifiers/dir2/H.coffee
+++ b/test/examples/multiple-path-specifiers/dir2/H.coffee
@@ -1,0 +1,1 @@
+console.log 'H'

--- a/test/examples/multiple-path-specifiers/paths.txt
+++ b/test/examples/multiple-path-specifiers/paths.txt
@@ -1,0 +1,3 @@
+A.coffee
+C.coffee
+./dir2/H.coffee

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -3,7 +3,7 @@ import 'babel-polyfill';
 
 import assert from 'assert';
 import { exec } from 'mz/child_process';
-import { readFile } from 'mz/fs';
+import { exists, readFile } from 'mz/fs';
 
 let originalCwd = process.cwd();
 
@@ -30,6 +30,10 @@ export function assertIncludes(output, substr) {
     output.includes(substr),
     `Expected the output to include "${substr}".\n\nFull output:\n${output}`
   );
+}
+
+export async function assertExists(path) {
+  assert(await exists(path), `Expected ${path} to exist.`);
 }
 
 export async function assertFileContents(path, expectedContents) {


### PR DESCRIPTION
This makes it possible to do an automatic search and also opt-in specific files
(like `Cakefile`).

BREAKING CHANGE: Rather than defining precedence rules for different path config
options, we now allow multiple options and union the results.

BREAKING CHANGE: Config files ending in .json are no longer supported. Config
files must be JS files ending in .config.js.