### PR TITLE
fix: provide proper paths when checking if scripts are executable

### DIFF
--- a/src/util/getFilesUnderPath.js
+++ b/src/util/getFilesUnderPath.js
@@ -16,7 +16,7 @@ export default async function getFilesUnderPath(dirPath, asyncPathPredicate) {
     if ((await stat(childPath)).isDirectory()) {
       let subdirCoffeeFiles = await getFilesUnderPath(childPath, asyncPathPredicate);
       resultFiles.push(...subdirCoffeeFiles);
-    } else if (await asyncPathPredicate(child)) {
+    } else if (await asyncPathPredicate(childPath)) {
       resultFiles.push(childPath);
     }
   }

--- a/test/bulk-decaffeinate-test.js
+++ b/test/bulk-decaffeinate-test.js
@@ -108,7 +108,7 @@ describe('check', () => {
     await runWithTemplateDir('executable-extensionless-scripts', async function() {
       let {stdout, stderr} = await runCli('check');
       assert.equal(stderr, '');
-      assertIncludes(stdout, 'Doing a dry run of decaffeinate on 1 file...');
+      assertIncludes(stdout, 'Doing a dry run of decaffeinate on 2 files...');
       assertIncludes(stdout, 'All checks succeeded');
     });
   });

--- a/test/convert-test.js
+++ b/test/convert-test.js
@@ -254,6 +254,13 @@ console.log('Ran the thing!');
 
 console.log('This script is executable so it should be converted.');
 `);
+      await assertFileContents('./bin/nestedExecutableScript', `\
+#!/usr/bin/env node
+// TODO: This file was created by bulk-decaffeinate.
+// Sanity-check the conversion and remove this comment.
+
+console.log('This nested script is executable so it should be converted.');
+`);
       await assertFileContents('./executableScriptWithoutShebang', untouchedContents1);
       await assertFileContents('./executableScriptWithWrongShebang', untouchedContents2);
       await assertFileContents('./nonExecutableScript', untouchedContents3);

--- a/test/examples/executable-extensionless-scripts/bin/nestedExecutableScript
+++ b/test/examples/executable-extensionless-scripts/bin/nestedExecutableScript
@@ -1,0 +1,3 @@
+#!/usr/bin/env coffee
+
+console.log 'This nested script is executable so it should be converted.'


### PR DESCRIPTION
Previously, if there was a nested extensionless script, bulk-decaffeinate would
crash because it would only use the filename, not the full path.