### PR TITLE
fix: change "clean" to remove all types of .original files

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ bulk-decaffeinate supports a number of commands:
   is in the hash fragment and not a regular query param, your code is never sent
   to the server.
 * `convert` actually converts the files from CofeeScript to JavaScript.
-* `clean` deletes all .original.coffee files in the current directory or any of
-  its subdirectories.
+* `clean` deletes all files with ".original" in the name in the current
+  directory or any of its subdirectories.
 * `land` packages multiple commits into a merge commit based on an remote branch
   (`origin/master` by default). Splitting the decaffeinate work into separate
   commits allows git to properly track file history, but it can create added

--- a/src/clean.js
+++ b/src/clean.js
@@ -1,15 +1,17 @@
 import { unlink } from 'mz/fs';
+import { basename } from 'path';
+
 import getFilesUnderPath from './util/getFilesUnderPath';
 
 export default async function clean() {
-  let filesToDelete = await getFilesUnderPath('.', p => p.endsWith('.original.coffee'));
+  let filesToDelete = await getFilesUnderPath('.', p => basename(p).includes('.original'));
   if (filesToDelete.length === 0) {
-    console.log('No .original.coffee files were found.');
+    console.log('No .original files were found.');
     return;
   }
   for (let path of filesToDelete) {
     console.log(`Deleting ${path}`);
     await unlink(path);
   }
-  console.log('Done deleting .original.coffee files.');
+  console.log('Done deleting .original files.');
 }

--- a/test/convert-test.js
+++ b/test/convert-test.js
@@ -1,10 +1,11 @@
 /* eslint-env mocha */
 import assert from 'assert';
 import { exec } from 'mz/child_process';
-import { exists, readFile, writeFile } from 'mz/fs';
+import { readFile, writeFile } from 'mz/fs';
 
 import {
   assertExists,
+  assertNotExists,
   assertFileContents,
   assertIncludes,
   initGitRepo,
@@ -315,18 +316,16 @@ console.log(x);
   });
 
   it('generates backup files that are removed by clean', async function() {
-    await runWithTemplateDir('simple-success', async function() {
+    await runWithTemplateDir('backup-files', async function() {
       await initGitRepo();
       await runCli('convert');
-      assert(
-        await exists('./A.original.coffee'),
-        'Expected a backup file to be created.'
-      );
+      await assertExists('./A.original.coffee');
+      await assertExists('./B.original.coffee.md');
+      await assertExists('./C.original');
       await runCli('clean');
-      assert(
-        !await exists('./A.original.coffee'),
-        'Expected the "clean" command to get rid of the backup file.'
-      );
+      await assertNotExists('./A.original.coffee');
+      await assertNotExists('./B.original.coffee.md');
+      await assertNotExists('./C.original');
     });
   });
 

--- a/test/examples/backup-files/A.coffee
+++ b/test/examples/backup-files/A.coffee
@@ -1,0 +1,1 @@
+console.log 'A'

--- a/test/examples/backup-files/B.coffee.md
+++ b/test/examples/backup-files/B.coffee.md
@@ -1,0 +1,3 @@
+Testing
+
+    console.log 'B'

--- a/test/examples/backup-files/C
+++ b/test/examples/backup-files/C
@@ -1,0 +1,3 @@
+#!/usr/bin/env coffee
+
+console.log 'C'

--- a/test/test-util.js
+++ b/test/test-util.js
@@ -36,6 +36,10 @@ export async function assertExists(path) {
   assert(await exists(path), `Expected ${path} to exist.`);
 }
 
+export async function assertNotExists(path) {
+  assert(!await exists(path), `Expected ${path} to not exist.`);
+}
+
 export async function assertFileContents(path, expectedContents) {
   let contents = (await readFile(path)).toString();
   assert.equal(contents, expectedContents);


### PR DESCRIPTION
This is a little unsafe in that it's more likely to get false positives, but
should still be safe since people should be running this within a git repo and
because it skips node_modules.