### PR TITLE
fix: convert paths to relative when invoking jscodeshift

### DIFF
--- a/src/convert.js
+++ b/src/convert.js
@@ -107,7 +107,7 @@ Re-run with the "check" command for more details.`);
       let resolvedPath = resolveJscodeshiftScriptPath(scriptPath);
       console.log(`Running jscodeshift script ${resolvedPath}...`);
       await execLive(`${config.jscodeshiftPath} --parser flow \
-        -t ${resolvedPath} ${jsFiles.join(' ')}`);
+        -t ${resolvedPath} ${jsFiles.map(p => relative('', p)).join(' ')}`);
     }
   }
 


### PR DESCRIPTION
This avoids a crash due to the shell command being too long, and should
hopefully avoid the new error in the codecombat example project.