### PR TITLE
feat: when specifying files from the CLI, ignore the equivalent config settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,8 +175,8 @@ If multiple of `searchDirectory`, `pathFile`, or `filesToProcess` are specified,
 the union of the files is taken. If none is specified, bulk-decaffeinate will
 recursively discover all CoffeeScript files in the working directory.
 
-Each of these has a command line arg version; see the result of `--help` for
-more information.
+Each of these has a command line arg version, which takes precedence over config
+file values; see the result of `--help` for more information.
 
 ### Other configuration
 

--- a/src/config/resolveConfig.js
+++ b/src/config/resolveConfig.js
@@ -86,6 +86,14 @@ function getCLIParamsConfig(config, commander) {
     jscodeshiftPath,
     eslintPath,
   } = commander;
+  // As a special case, specifying files to process from the CLI should cause
+  // any equivalent config file settings to be ignored.
+  if ((file && file.length > 0) || dir || pathFile) {
+    config.filesToProcess = null;
+    config.searchDirectory = null;
+    config.pathFile = null;
+  }
+
   if (file && file.length > 0) {
     config.filesToProcess = file;
   }

--- a/test/bulk-decaffeinate-test.js
+++ b/test/bulk-decaffeinate-test.js
@@ -132,4 +132,13 @@ describe('check', () => {
       assertIncludes(stdout, 'All checks succeeded');
     });
   });
+
+  it('ignores config file paths when CLI arg paths are specified', async function() {
+    await runWithTemplateDir('search-directory-config', async function() {
+      let {stdout, stderr} = await runCli('check -f ./A.coffee');
+      assert.equal(stderr, '');
+      assertIncludes(stdout, 'Doing a dry run of decaffeinate on 1 file...');
+      assertIncludes(stdout, 'All checks succeeded');
+    });
+  });
 });

--- a/test/examples/search-directory-config/A.coffee
+++ b/test/examples/search-directory-config/A.coffee
@@ -1,0 +1,1 @@
+console.log 'Hello'

--- a/test/examples/search-directory-config/B.coffee
+++ b/test/examples/search-directory-config/B.coffee
@@ -1,0 +1,1 @@
+console.log 'World'

--- a/test/examples/search-directory-config/bulk-decaffeinate.config.js
+++ b/test/examples/search-directory-config/bulk-decaffeinate.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  searchDirectory: '.',
+};


### PR DESCRIPTION
This fixes an annoyance that was also causing trouble in the
decaffeinate-examples project. When specifying a path file, like the successful
files after `check`, it should only convert those files, not union them with the
existing config.