### PR TITLE
feat: update bulk-decaffeinate for decaffeinate 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,34 +13,41 @@ some follow-up cleanups. Here's an example of checking the Hubot repo:
 ```
 > npm install -g bulk-decaffeinate decaffeinate eslint
 ...
-> git clone git@github.com:github/hubot.git
+> git clone https://github.com/philc/vimium.git
 ...
-> cd hubot
+> cd vimium
 > bulk-decaffeinate check
-Doing a dry run of decaffeinate on 18 files...
-18/18 (5 failures so far)
-5 files failed to convert:
-src/adapter.coffee
-src/adapters/campfire.coffee
-src/brain.coffee
-src/listener.coffee
-src/message.coffee
-
-Wrote decaffeinate-errors.log and decaffeinate-results.json with more detailed info.
-To open failures in the online repl, run "bulk-decaffeinate view-errors".
-To convert the successful files, run "bulk-decaffeinate convert -p decaffeinate-successful-files.txt".
-> bulk-decaffeinate view-errors
-(7 browser tabs are opened, showing all failures.)
-> bulk-decaffeinate check --allow-invalid-constructors
-Doing a dry run of decaffeinate on 18 files...
-18/18
-All checks succeeded! decaffeinate can convert all 18 files.
+Doing a dry run of decaffeinate on 50 files...
+50/50
+All checks succeeded! decaffeinate can convert all 50 files.
 Run "bulk-decaffeinate convert" to convert the files to JavaScript.
+> bulk-decaffeinate convert
+Verifying that decaffeinate can successfully convert these files...
+50/50
+Backing up files to .original.coffee...
+50/50
+Renaming files from .coffee to .js...
+50/50
+Generating the first commit: "decaffeinate: Rename bg_utils.coffee and 49 other files from .coffee to .js"...
+Moving files back...
+50/50
+Running decaffeinate on all files...
+50/50
+Deleting old files...
+50/50
+Setting proper extension for all files...
+50/50
+Generating the second commit: decaffeinate: Convert bg_utils.coffee and 49 other files to JS...
+Running eslint --fix on all files...
+50/50
+[Skips eslint for all files because there is no config.]
+Generating the third commit: decaffeinate: Run post-processing cleanups on bg_utils.coffee and 49 other files...
+Successfully ran decaffeinate on 50 files.
+You should now fix lint issues in any affected files.
+All CoffeeScript files were backed up as .original.coffee files that you can use for comparison.
+You can run "bulk-decaffeinate clean" to remove those files.
+To allow git to properly track file history, you should NOT squash the generated commits together.
 ```
-
-Once any failures are resolved (generally by tweaking the CoffeeScript to work
-with decaffeinate), the command `bulk-decaffeinate convert` generates three git
-commits to convert the files to JS.
 
 ## Assumptions
 
@@ -178,19 +185,16 @@ recursively discover all CoffeeScript files in the working directory.
 Each of these has a command line arg version, which takes precedence over config
 file values; see the result of `--help` for more information.
 
-### Other configuration
+### Common configuration options
 
+* `useJSModules`: an optional boolean. If true, decaffeinate will be configured
+  to produce code with `import`/`export` syntax, and the fix-imports step will
+  be run afterward to correct any import statements across the codebase. The
+  fix-imports step can be configured using `fixImportsConfig`.
 * `decaffeinateArgs`: an optional array of additional command-line arguments to
   pass to decaffeinate. For example, `['--keep-commonjs']` sets the preference
   to keep `require` and `module.exports` rather than converting them to `import`
   and `export`.
-* `customNames`: an optional object mapping old filename to new filename. By
-  default, the extension is removed and replaced with ".js" (or nothing for
-  extensionless files), but this mapping can be used to override the behavior
-  to provide a specific target directory, name, and/or file extension for any
-  specific files being converted.
-* `outputFileExtension`: an optional file extension, like `"ts"` or `"jsx"`. If
-  specified, all converted files will have this extension.
 * `jscodeshiftScripts`: an optional array of paths to
   [jscodeshift](https://github.com/facebook/jscodeshift) scripts to run after
   decaffeinate. This is useful to automate any cleanups to convert the output of
@@ -211,6 +215,16 @@ file values; see the result of `--help` for more information.
     as an absolute path starting point when resolving imports. This is necessary
     if you do any tricks to get absolute-style imports in your project, since
     the fix-imports script needs to be able to resolve import names to files.
+
+### Other configuration
+
+* `customNames`: an optional object mapping old filename to new filename. By
+  default, the extension is removed and replaced with ".js" (or nothing for
+  extensionless files), but this mapping can be used to override the behavior
+  to provide a specific target directory, name, and/or file extension for any
+  specific files being converted.
+* `outputFileExtension`: an optional file extension, like `"ts"` or `"jsx"`. If
+  specified, all converted files will have this extension.
 * `mochaEnvFilePattern`: an optional regular expression string. If specified,
   all generated JavaScript files with a path matching this pattern have the text
   `/* eslint-env mocha */` added to the start. For example, `"^.*-test.js$"`.

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "babel-preset-es2015": "^6.13.0",
     "babel-register": "^6.11.6",
     "babelrc-rollup": "^3.0.0",
-    "decaffeinate": "^2.55.0",
+    "decaffeinate": "^3.0.0",
     "eslint": "^3.18.0",
     "eslint-plugin-babel": "^4.0.0",
     "jscodeshift": "^0.3.30",

--- a/src/cli.js
+++ b/src/cli.js
@@ -41,9 +41,10 @@ export default function () {
     .option('-d, --dir [path]',
       `A directory containing files to decaffeinate. All .coffee files in
                               any subdirectory of this directory are considered for decaffeinate.`)
-    .option('--allow-invalid-constructors',
-      `If specified, the --allow-invalid-constructors arg is added when
-                              invoking decaffeinate.`)
+    .option('--use-js-modules',
+      `If specified, decaffeinate will convert the code to use import/export
+                              syntax and a follow-up fix-imports step will correct any imports
+                              across the codebase.`)
     .option('--land-base [revision]',
       `The git revision to use as the base commit when running the "land"
                               command. If none is specified, bulk-decaffeinate tries to use the
@@ -61,6 +62,8 @@ export default function () {
     .option('--eslint-path [path]',
       `The path to the eslint binary. If none is specified, it will be
                               automatically discovered from node_modules and then from the PATH.`)
+    .option('--allow-invalid-constructors',
+      `Deprecated; decaffeinate now allows invalid constructors by default.`)
     .parse(process.argv);
 
   runCommand(command);

--- a/test/convert-test.js
+++ b/test/convert-test.js
@@ -82,7 +82,7 @@ Sample User <sample@example.com> Initial commit
 */
 // TODO: This file was created by bulk-decaffeinate.
 // Fix any style issues and re-enable lint.
-let a = 1;
+const a = 1;
 `);
       await assertFileContents('./B.js', `\
 /* eslint-disable
@@ -91,7 +91,7 @@ let a = 1;
 // TODO: This file was created by bulk-decaffeinate.
 // Fix any style issues and re-enable lint.
 // This is a literate file.
-let b = 1;
+const b = 1;
 `);
       await assertFileContents('./C.js', `\
 /* eslint-disable
@@ -100,7 +100,7 @@ let b = 1;
 // TODO: This file was created by bulk-decaffeinate.
 // Fix any style issues and re-enable lint.
 // This is another literate file.
-let c = 1;
+const c = 1;
 `);
     });
   });
@@ -114,8 +114,8 @@ let c = 1;
 */
 // TODO: This file was created by bulk-decaffeinate.
 // Fix any style issues and re-enable lint.
-let nameAfter = 3;
-let notChanged = 4;
+const nameAfter = 3;
+const notChanged = 4;
 `);
     });
   });
@@ -129,7 +129,14 @@ let notChanged = 4;
 */
 // TODO: This file was created by bulk-decaffeinate.
 // Fix any style issues and re-enable lint.
-let a = require('./A');
+/*
+ * decaffeinate suggestions:
+ * DS102: Remove unnecessary code created because of implicit returns
+ * DS208: Avoid top-level this
+ * DS209: Avoid top-level return
+ * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
+ */
+const a = require('./A');
 
 // This is a comment
 function f() {
@@ -203,7 +210,7 @@ console.log('This is a file');
 */
 // TODO: This file was created by bulk-decaffeinate.
 // Fix any style issues and re-enable lint.
-let a = require('b');
+const a = require('b');
 module.exports = c;
 `);
     });
@@ -370,19 +377,6 @@ Proceeding anyway.`);
       await exec('chmod +x .git/hooks/commit-msg');
       await runCliExpectSuccess('convert');
       assert.equal((await exec('git rev-list --count HEAD'))[0].trim(), '4');
-    });
-  });
-
-  it('allows invalid constructors when specified', async function() {
-    await runWithTemplateDir('invalid-subclass-constructor', async function() {
-      await runCliExpectSuccess('convert --allow-invalid-constructors');
-    });
-  });
-
-  it('does not allow invalid constructors when not specified', async function() {
-    await runWithTemplateDir('invalid-subclass-constructor', async function() {
-      let message = await runCliExpectError('convert');
-      assertIncludes(message, 'Some files could not be converted with decaffeinate');
     });
   });
 });

--- a/test/examples/fix-imports-absolute-imports/bulk-decaffeinate.config.js
+++ b/test/examples/fix-imports-absolute-imports/bulk-decaffeinate.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  decaffeinateArgs: ['--loose-js-modules'],
   fixImportsConfig: {
     searchPath: '.',
     absoluteImportPaths: ['.'],

--- a/test/examples/fix-imports-default-import-to-import-star/bulk-decaffeinate.config.js
+++ b/test/examples/fix-imports-default-import-to-import-star/bulk-decaffeinate.config.js
@@ -1,5 +1,3 @@
 module.exports = {
-  fixImportsConfig: {
-    searchPath: '.',
-  },
+  decaffeinateArgs: ['--loose-js-modules'],
 };

--- a/test/examples/fix-imports-destructure-from-import-star/bulk-decaffeinate.config.js
+++ b/test/examples/fix-imports-destructure-from-import-star/bulk-decaffeinate.config.js
@@ -1,5 +1,3 @@
 module.exports = {
-  fixImportsConfig: {
-    searchPath: '.',
-  },
+  decaffeinateArgs: ['--loose-js-modules'],
 };

--- a/test/examples/fix-imports-export-function/bulk-decaffeinate.config.js
+++ b/test/examples/fix-imports-export-function/bulk-decaffeinate.config.js
@@ -1,5 +1,0 @@
-module.exports = {
-  fixImportsConfig: {
-    searchPath: '.',
-  },
-};

--- a/test/examples/fix-imports-import-commonjs/bulk-decaffeinate.config.js
+++ b/test/examples/fix-imports-import-commonjs/bulk-decaffeinate.config.js
@@ -1,5 +1,0 @@
-module.exports = {
-  fixImportsConfig: {
-    searchPath: '.',
-  },
-};

--- a/test/examples/fix-imports-import-from-existing-js/bulk-decaffeinate.config.js
+++ b/test/examples/fix-imports-import-from-existing-js/bulk-decaffeinate.config.js
@@ -1,5 +1,3 @@
 module.exports = {
-  fixImportsConfig: {
-    searchPath: '.',
-  },
+  decaffeinateArgs: ['--loose-js-modules'],
 };

--- a/test/examples/fix-imports-named-import-to-destructure/NamedImport.js.expected
+++ b/test/examples/fix-imports-named-import-to-destructure/NamedImport.js.expected
@@ -22,7 +22,7 @@ const {
 
 console.log(twelve);
 console.log(tenAndSeven);
-let NameClash = 25;
+const NameClash = 25;
 console.log(twenty);
 console.log(twentySix);
 console.log(NameClash);

--- a/test/examples/fix-imports-named-import-to-destructure/bulk-decaffeinate.config.js
+++ b/test/examples/fix-imports-named-import-to-destructure/bulk-decaffeinate.config.js
@@ -1,5 +1,3 @@
 module.exports = {
-  fixImportsConfig: {
-    searchPath: '.',
-  },
+  decaffeinateArgs: ['--loose-js-modules'],
 };

--- a/test/examples/fix-imports-no-name-usages/bulk-decaffeinate.config.js
+++ b/test/examples/fix-imports-no-name-usages/bulk-decaffeinate.config.js
@@ -1,5 +1,0 @@
-module.exports = {
-  fixImportsConfig: {
-    searchPath: '.',
-  },
-};

--- a/test/examples/fix-imports-non-relative-path/bulk-decaffeinate.config.js
+++ b/test/examples/fix-imports-non-relative-path/bulk-decaffeinate.config.js
@@ -1,5 +1,3 @@
 module.exports = {
-  fixImportsConfig: {
-    searchPath: '.',
-  },
+  decaffeinateArgs: ['--loose-js-modules'],
 };

--- a/test/examples/fix-imports-star-import-from-existing-js/bulk-decaffeinate.config.js
+++ b/test/examples/fix-imports-star-import-from-existing-js/bulk-decaffeinate.config.js
@@ -1,5 +1,0 @@
-module.exports = {
-  fixImportsConfig: {
-    searchPath: '.',
-  },
-};

--- a/test/examples/invalid-subclass-constructor/A.coffee
+++ b/test/examples/invalid-subclass-constructor/A.coffee
@@ -1,4 +1,0 @@
-class A extends B
-  constructor: ->
-    @a = 1
-    super

--- a/test/fix-imports-test.js
+++ b/test/fix-imports-test.js
@@ -15,7 +15,7 @@ describe('fix-imports', () => {
     await runWithTemplateDir(dirName, async function () {
       // We intentionally call the files ".js.expected" so that jscodeshift
       // doesn't discover and try to convert them.
-      let {stdout, stderr} = await runCli('convert');
+      let {stdout, stderr} = await runCli('convert --use-js-modules');
       assertIncludes(stdout, 'Fixing any imports across the whole codebase');
       assert.equal(stderr, '');
 

--- a/test/modernize-js-test.js
+++ b/test/modernize-js-test.js
@@ -16,7 +16,7 @@ describe('modernize-js', () => {
 */
 // TODO: This file was updated by bulk-decaffeinate.
 // Fix any style issues and re-enable lint.
-let a = 1;
+const a = 1;
 `);
     });
   });
@@ -31,7 +31,7 @@ let a = 1;
 */
 // TODO: This file was updated by bulk-decaffeinate.
 // Fix any style issues and re-enable lint.
-let a = 1;
+const a = 1;
 `);
     });
   });
@@ -40,7 +40,7 @@ let a = 1;
     await runWithTemplateDir('modernize-no-lint-failure', async function() {
       await runCliExpectSuccess('modernize-js');
       await assertFileContents('./A.js', `\
-import path from 'path';
+const path = require('path');
 path.resolve();
 `);
     });
@@ -55,8 +55,8 @@ path.resolve();
 */
 // TODO: This file was updated by bulk-decaffeinate.
 // Fix any style issues and re-enable lint.
-let nameAfter = 1;
-let notChanged = 2;
+const nameAfter = 1;
+const notChanged = 2;
 `);
     });
   });


### PR DESCRIPTION
* Add a `--use-js-modules` option that performs the fix-imports step and sets
  the decaffeinate args to use JS modules.
* Update a bunch of tests to reflect the defaults changes.
* Make the `--allow-invalid-constructors` option a no-op, since it isn't needed
  with decaffeinate 3.0.
* Update the README example to no longer use `--allow-invalid-constructors`.
  Also change it from hubot to coffeelint, since hubot is now a JS project.

BREAKING CHANGE: The `--allow-invalid-constructors` option is now a no-op.