### PR TITLE
fix: properly detect missing eslint config file for newer eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "babel-register": "^6.11.6",
     "babelrc-rollup": "^3.0.0",
     "decaffeinate": "^3.0.0",
-    "eslint": "^3.18.0",
+    "eslint": "^4.10.0",
     "eslint-plugin-babel": "^4.0.0",
     "jscodeshift": "^0.3.30",
     "mocha": "^3.0.2",


### PR DESCRIPTION
Fixes #134

Newer eslint puts the message on stderr, and older eslint puts it on stdout, so
just check both.