### PR TITLE
feat: add an option to skip the eslint step

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ file values; see the result of `--help` for more information.
   the `convert` command. This makes bulk-decaffeinate take less time, but if any
   files fail to convert, it may leave the filesystem in a partially-converted
   state.
+* `skipEslintFix`: set to `true` to skip the ESLint step.
 
 ### Configuring paths to external tools
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -77,10 +77,10 @@ async function runCommand(command) {
       let config = await resolveConfig(commander);
       await check(config);
     } else if (command === 'convert') {
-      let config = await resolveConfig(commander);
+      let config = await resolveConfig(commander, {needsJscodeshift: true, needsEslint: true});
       await convert(config);
     } else if (command === 'modernize-js') {
-      let config = await resolveConfig(commander);
+      let config = await resolveConfig(commander, {needsJscodeshift: true, needsEslint: true});
       await modernizeJS(config);
     } else if (command === 'view-errors') {
       await viewErrors();

--- a/src/config/resolveConfig.js
+++ b/src/config/resolveConfig.js
@@ -11,7 +11,7 @@ import execLive from '../util/execLive';
  * Resolve the configuration from a number of sources: any number of config
  * files and CLI options. Then "canonicalize" the config as much as we can.
  */
-export default async function resolveConfig(commander) {
+export default async function resolveConfig(commander, {needsJscodeshift, needsEslint} = {}) {
   let config = {};
 
   if (commander.config && commander.config.length > 0) {
@@ -42,9 +42,10 @@ export default async function resolveConfig(commander) {
     landBase: config.landBase,
     numWorkers: config.numWorkers || 8,
     skipVerify: config.skipVerify,
+    skipEslintFix: config.skipEslintFix,
     decaffeinatePath: await resolveDecaffeinatePath(config),
-    jscodeshiftPath: await resolveJscodeshiftPath(config),
-    eslintPath: await resolveEslintPath(config),
+    jscodeshiftPath: needsJscodeshift ? await resolveJscodeshiftPath(config) : null,
+    eslintPath: needsEslint ? await resolveEslintPath(config) : null,
   };
 }
 
@@ -167,6 +168,9 @@ async function resolveJscodeshiftPath(config) {
 }
 
 async function resolveEslintPath(config) {
+  if (config.skipEslintFix) {
+    return null;
+  }
   if (config.eslintPath) {
     return config.eslintPath;
   }

--- a/src/convert.js
+++ b/src/convert.js
@@ -125,7 +125,9 @@ Re-run with the "check" command for more details.`);
   if (config.fixImportsConfig) {
     thirdCommitModifiedFiles = await runFixImports(jsFiles, config);
   }
-  await runEslintFix(jsFiles, config, {isUpdate: false});
+  if (!config.skipEslintFix) {
+    await runEslintFix(jsFiles, config, {isUpdate: false});
+  }
   if (config.codePrefix) {
     await prependCodePrefix(config, jsFiles, config.codePrefix);
   }

--- a/src/modernizeJS.js
+++ b/src/modernizeJS.js
@@ -30,7 +30,9 @@ export default async function modernizeJS(config) {
   if (config.fixImportsConfig) {
     await runFixImports(jsFiles, config);
   }
-  await runEslintFix(jsFiles, config, {isUpdate: true});
+  if (!config.skipEslintFix) {
+    await runEslintFix(jsFiles, config, {isUpdate: true});
+  }
 
   console.log(`Successfully modernized ${pluralize(jsFiles.length, 'file')}.`);
   console.log('You should now fix lint issues in any affected files.');

--- a/test/convert-test.js
+++ b/test/convert-test.js
@@ -379,4 +379,11 @@ Proceeding anyway.`);
       assert.equal((await exec('git rev-list --count HEAD'))[0].trim(), '4');
     });
   });
+
+  it('allows skipping eslint --fix', async function() {
+    await runWithTemplateDir('skip-eslint-fix', async function() {
+      const {stdout} = await runCliExpectSuccess('convert');
+      assert(!stdout.includes('Running eslint'), 'Expected eslint to be skipped.');
+    });
+  });
 });

--- a/test/examples/skip-eslint-fix/A.coffee
+++ b/test/examples/skip-eslint-fix/A.coffee
@@ -1,0 +1,1 @@
+console.log 'Hello world'

--- a/test/examples/skip-eslint-fix/bulk-decaffeinate.config.js
+++ b/test/examples/skip-eslint-fix/bulk-decaffeinate.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  skipEslintFix: true,
+};


### PR DESCRIPTION
This is useful if you're not using eslint for whatever reason or to reduce the
total running time.

This also changes the requirements code to be a little smarter and not prompt to
install things that we don't need for the current operation.