### PR TITLE
fix: update node versions run on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,9 @@ cache:
 notifications:
   email: false
 node_js:
+  - '10'
+  - '8'
   - '6'
-  - '4'
 before_install:
   - npm i -g npm@^2.0.0
 before_script:

--- a/jscodeshift-scripts/fix-imports.js
+++ b/jscodeshift-scripts/fix-imports.js
@@ -25,7 +25,7 @@ import zlib from 'zlib';
 export default function (fileInfo, api, options) {
   let decodedOptions = JSON.parse(
     zlib.inflateSync(
-      new Buffer(options['encoded-options'], 'base64')
+      Buffer.from(options['encoded-options'], 'base64')
     ).toString()
   );
   let {convertedFiles, absoluteImportPaths} = decodedOptions;


### PR DESCRIPTION
This should fix the build. I won't call it a breaking change since it doesn't
cause any breaking changes in the package. Node 4 hasn't been supported in
quite a while anyway, so I won't bother looking into the specific failure.

Also update a usage of Buffer to fix a warning in node 10.